### PR TITLE
Make xpack.monitoring configurable

### DIFF
--- a/jobs/logstash/spec
+++ b/jobs/logstash/spec
@@ -46,10 +46,10 @@ properties:
   logstash.env:
     description: A hash of envrioment varibales
   logstash.readiness_probe_http_port:
-    descrititon: HTTP port to check the readiness of Logstash server. Set 0 to disable the http readiness probe.
+    description: HTTP port to check the readiness of Logstash server. Set 0 to disable the http readiness probe.
     default: 9600
   logstash.readiness_probe_tcp_port:
-    descrititon: TCP port to check the readiness of Logstash server. Set 0 to disable the TCP readiness probe.
+    description: TCP port to check the readiness of Logstash server. Set 0 to disable the TCP readiness probe.
     default: 0
   logstash.kill_and_wait_timeout:
     default: timeout for kill_and_wait function

--- a/jobs/logstash/spec
+++ b/jobs/logstash/spec
@@ -7,10 +7,12 @@ templates:
   bin/ctl_utils.sh: bin/ctl_utils.sh
   bin/tcp_probe.py: bin/tcp_probe.py
   config/logstash.conf: config/logstash.conf
+  config/logstash.yml: config/logstash.yml
   config/tls.crt: config/tls.crt
   config/tls.key: config/tls.key
   config/env.sh: config/env.sh
   config/elasticsearch-hosts: config/elasticsearch-hosts
+  config/elasticsearch-ca.crt: config/elasticsearch-ca.crt
 
 packages:
 - logstash
@@ -70,3 +72,32 @@ properties:
     description: "The username of basic authentication on Elasticsearch"
   elasticsearch.password:
     description: "The password of basic authentication on Elasticsearch"
+  xpack.monitoring.enabled:
+    description: "Monitoring is disabled by default. Set to `true` to enable X-Pack monitoring."
+  xpack.monitoring.elasticsearch.url:
+    description: "The Elasticsearch instances that you want to ship your Logstash metrics to. This might be the same Elasticsearch instance specified in the `outputs` section in your Logstash configuration, or a different one. This is not the URL of your dedicated monitoring cluster. Even if you are using a dedicated monitoring cluster, the Logstash metrics must be routed through your production cluster. You can specify a single host as a string, or specify multiple hosts as an array. Defaults to `http://localhost:9200`."
+  xpack.monitoring.elasticsearch.username:
+    description: "If your Elasticsearch is protected with basic authentication, these settings provide the username and password that the Logstash instance uses to authenticate for shipping monitoring data."
+  xpack.monitoring.elasticsearch.password:
+    description: "If your Elasticsearch is protected with basic authentication, these settings provide the username and password that the Logstash instance uses to authenticate for shipping monitoring data."
+  xpack.monitoring.collection.interval:
+    description: "Controls how often data samples are collected and shipped on the Logstash side. Defaults to `10s`. If you modify the collection interval, set the `xpack.monitoring.min_interval_seconds` option in `kibana.yml` to the same value."
+  xpack.monitoring.elasticsearch.ssl.ca:
+    description: "Optional setting that enables you to specify a path to the `.pem` file for the certificate authority for your Elasticsearch instance."
+  xpack.monitoring.elasticsearch.ssl.certificate_authority: #After Logstash 6.7
+    description: "Optional setting that enables you to specify a path to the `.pem` file for the certificate authority for your Elasticsearch instance."
+  xpack.monitoring.elasticsearch.ssl.truststore.path:
+    description: "Optional settings that provide the paths to the Java keystore (JKS) to validate the server’s certificate."
+  xpack.monitoring.elasticsearch.ssl.truststore.password:
+    description: "Optional settings that provide the password to the truststore."
+  xpack.monitoring.elasticsearch.ssl.keystore.path:
+    description: "Optional settings that provide the paths to the Java keystore (JKS) to validate the client’s certificate."
+  xpack.monitoring.elasticsearch.ssl.keystore.password:
+    description: "Optional settings that provide the password to the keystore."
+  xpack.monitoring.elasticsearch.ssl.verification_mode:
+    description: |
+      "Controls the verification of certificates. Valid values are:"
+      "- `full`, which verifies that the provided certificate is signed by a trusted authority (CA) and also verifies that the server’s hostname (or IP address) matches the names identified within the certificate."
+      "- `certificate`, which verifies that the provided certificate is signed by a trusted authority (CA), but does not perform any hostname verification."
+      "- `none`, which performs no verification of the server’s certificate. This mode disables many of the security benefits of SSL/TLS and should only be used after very careful consideration. It is primarily intended as a temporary diagnostic mechanism when attempting to resolve TLS errors, and its use on production clusters is strongly discouraged."
+      "- The default value is `full`."

--- a/jobs/logstash/templates/bin/ctl
+++ b/jobs/logstash/templates/bin/ctl
@@ -37,6 +37,7 @@ case $1 in
       --path.config $JOB_DIR/config/logstash-es.conf \
       --path.data $STORE_DIR \
       --path.logs $LOG_DIR \
+      --path.settings $JOB_DIR/config \
       >>$LOG_DIR/logstash.stdout.log 2>>$LOG_DIR/logstash.stderr.log
     ;;
 

--- a/jobs/logstash/templates/config/elasticsearch-ca.crt
+++ b/jobs/logstash/templates/config/elasticsearch-ca.crt
@@ -1,0 +1,1 @@
+<% if_p("xpack.monitoring.elasticsearch.ssl.ca") do | ca | %><%= ca %><% end %>

--- a/jobs/logstash/templates/config/logstash.yml
+++ b/jobs/logstash/templates/config/logstash.yml
@@ -1,3 +1,4 @@
+node.name: <%= name %>/<%= index %>
 <% if_p('xpack.monitoring.enabled') do |enabled| -%>
 xpack.monitoring.enabled: <%= enabled %>
 <%

--- a/jobs/logstash/templates/config/logstash.yml
+++ b/jobs/logstash/templates/config/logstash.yml
@@ -1,0 +1,38 @@
+<% if_p('xpack.monitoring.enabled') do |enabled| -%>
+xpack.monitoring.enabled: <%= enabled %>
+<%
+  es_hosts = nil
+  if_link("elasticsearch") { |elasticsearch_link| es_hosts = elasticsearch_link.instances.map {|e| p("elasticsearch.protocol") + "://" + e.address + ":" + p("elasticsearch.port")} }
+  unless es_hosts
+    es_hosts = p("elasticsearch.hosts")
+  end
+-%>
+xpack.monitoring.elasticsearch.url: <%= es_hosts %>
+<% if_p('elasticsearch.username') do |username| -%>
+xpack.monitoring.elasticsearch.username: <%= username %>
+<% end -%>
+<% if_p('elasticsearch.password') do |password| -%>
+xpack.monitoring.elasticsearch.password: <%= password %>
+<% end -%>
+<% if_p('xpack.monitoring.collection.interval') do |interval| -%>
+xpack.monitoring.collection.interval: <%= interval %>
+<% end -%>
+<% if_p('xpack.monitoring.elasticsearch.ssl.ca') do |ca| -%>
+xpack.monitoring.elasticsearch.ssl.ca: /var/vcap/jobs/logstash/config/elasticsearch-ca.crt
+<% end -%>
+<% if_p('xpack.monitoring.elasticsearch.ssl.truststore.path') do |path| -%>
+xpack.monitoring.elasticsearch.ssl.truststore.path: <%= path %>
+<% end -%>
+<% if_p('xpack.monitoring.elasticsearch.ssl.truststore.password') do |password| -%>
+xpack.monitoring.elasticsearch.ssl.truststore.password: <%= password %>
+<% end -%>
+<% if_p('xpack.monitoring.elasticsearch.ssl.keystore.path') do |path| -%>
+xpack.monitoring.elasticsearch.ssl.keystore.path: <%= path %>
+<% end -%>
+<% if_p('xpack.monitoring.elasticsearch.ssl.keystore.password') do |password| -%>
+xpack.monitoring.elasticsearch.ssl.keystore.password: <%= password %>
+<% end -%>
+<% if_p('xpack.monitoring.elasticsearch.ssl.verification_mode') do |verification_mode| -%>
+xpack.monitoring.elasticsearch.ssl.verification_mode: <%= verification_mode %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
X-Pack Monitoring settings in Logstash on v6.6. X-Pack Monitoring can be used with no subscription. Plugins are installed by default.

https://www.elastic.co/guide/en/logstash/6.6/configuring-logstash.html

I also created ops-file for enabling monitorign in `elastic-stack-bosh-deployment`.